### PR TITLE
Add first functional integration test for EditEndpoint

### DIFF
--- a/includes/MediaWiki/Api/EditEndpoint.php
+++ b/includes/MediaWiki/Api/EditEndpoint.php
@@ -17,6 +17,7 @@ use Wikibase\DataModel\Entity\ItemId;
 use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\Lib\Store\EntityIdLookup;
+use Wikibase\Lib\Store\EntityRevision;
 use Wikibase\Repo\WikibaseRepo;
 use Wikimedia\ParamValidator\ParamValidator;
 
@@ -181,6 +182,12 @@ class EditEndpoint extends SimpleHandler {
 		$response = [
 			'success' => $saveStatus->isGood()
 		];
+		if ( $saveStatus->isGood() ) {
+			/** @var EntityRevision $entityRevision */
+			$entityRevision = $saveStatus->getValue()['revision'];
+			$response['entityId'] = $entityRevision->getEntity()->getId()->getSerialization();
+			$response['revisionId'] = $entityRevision->getRevisionId();
+		}
 		return json_encode( $response );
 	}
 

--- a/tests/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/integration/MediaWiki/Api/EditEndpointTest.php
@@ -6,7 +6,13 @@ use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\RequestInterface;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\Property;
+use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
+use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\Repo\WikibaseRepo;
 
 /**
  * @covers MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint
@@ -15,6 +21,12 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 
 	use HandlerTestTrait;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'page';
+		$this->tablesUsed[] = 'wb_property_info';
+	}
 
 	private function newHandler() {
 		return new EditEndpoint();
@@ -28,6 +40,47 @@ class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 			],
 			'method' => 'POST',
 		] );
+	}
+
+	public function testCreateNewItem(): void {
+		/** @var PropertyId $propertyId */
+		$propertyId = WikibaseRepo::getDefaultInstance()->getEntityStore()->saveEntity(
+			new Property( null, null, 'url' ),
+			__METHOD__,
+			$this->getTestUser()->getUser(),
+			EDIT_NEW
+		)->getEntity()->getId();
+
+		$response = $this->executeHandlerAndGetBodyData(
+			$this->newHandler(),
+			$this->newRequest( [
+				'entity' => [
+					EditEndpoint::VERSION_KEY => '0.0.1/minimal',
+					'statements' => [
+						[
+							'property' => $propertyId->getSerialization(),
+							'value' => 'http://example.com/',
+						],
+					],
+				],
+				'reconcile' => [
+					EditEndpoint::VERSION_KEY => '0.0.1',
+					'urlReconcile' => $propertyId->getSerialization(),
+				],
+			] )
+		);
+		$response = json_decode( $response['value'], true );
+		$this->assertTrue( $response['success'] );
+
+		$itemId = new ItemId( $response['entityId'] );
+		/** @var Item $item */
+		$item = WikibaseRepo::getDefaultInstance()->getEntityLookup()->getEntity( $itemId );
+		$snaks = $item->getStatements()->getByPropertyId( $propertyId )->getMainSnaks();
+		$this->assertCount( 1, $snaks );
+		/** @var PropertyValueSnak $snak */
+		$snak = $snaks[0];
+		$this->assertInstanceOf( PropertyValueSnak::class, $snak );
+		$this->assertSame( 'http://example.com/', $snak->getDataValue()->getValue() );
 	}
 
 	public function testExecuteNoPropertyFound() {

--- a/tests/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/integration/MediaWiki/Api/EditEndpointTest.php
@@ -4,6 +4,7 @@ namespace MediaWiki\Extension\WikibaseReconcileEdit\Test\MediaWiki\Api;
 
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint;
 use MediaWiki\Rest\RequestData;
+use MediaWiki\Rest\RequestInterface;
 use MediaWiki\Tests\Rest\Handler\HandlerTestTrait;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 
@@ -19,21 +20,25 @@ class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 		return new EditEndpoint();
 	}
 
+	private function newRequest( array $params ): RequestInterface {
+		return new RequestData( [
+			'postParams' => array_map( 'json_encode', $params ),
+			'headers' => [
+				'Content-Type' => 'application/json',
+			],
+			'method' => 'POST',
+		] );
+	}
+
 	public function testExecuteNoPropertyFound() {
 		$reconcilePayload = [
 			'urlReconcile' => 'P1',
 			EditEndpoint::VERSION_KEY => '0.0.1'
 		];
 
-		$request = new RequestData( [
-			'postParams' => [
-				'entity' => 'Q1',
-				'reconcile' => json_encode( $reconcilePayload )
-			],
-			'headers' => [
-				'Content-Type' => 'json'
-			],
-			'method' => 'POST'
+		$request = $this->newRequest( [
+			'entity' => 'Q1',
+			'reconcile' => $reconcilePayload,
 		] );
 
 		$handler = $this->newHandler();


### PR DESCRIPTION
This test successfully uses the EditEndpoint API to create a new item,
and then asserts that it has the right reconciliation URL. To make this
possible, we also need to add some data to the EditEndpoint response.

The test can surely be improved later (e.g. extract some methods), but
it’s a start.

Bug: [T281798](https://phabricator.wikimedia.org/T281798)

---

Note: branch includes #6.