### PR TITLE
Compare el_to in ExternalLinks

### DIFF
--- a/includes/MediaWiki/ExternalLinks.php
+++ b/includes/MediaWiki/ExternalLinks.php
@@ -28,6 +28,7 @@ class ExternalLinks {
 			'externallinks',
 			'el_from',
 			[
+				'el_to' => $url,
 				'el_index' => $this->getSingleIndexOrDie( $url ),
 			],
 			__METHOD__

--- a/tests/integration/MediaWiki/ExternalLinksTest.php
+++ b/tests/integration/MediaWiki/ExternalLinksTest.php
@@ -70,6 +70,22 @@ class ExternalLinksTest extends \MediaWikiIntegrationTestCase {
 		$this->assertSame( [ '1' ], $result );
 	}
 
+	public function testPageIdsContainingLinksWithDifferentUserinfo(): void {
+		$userinfoAndPageIds = [
+			[ 'me:mypassword', 1 ],
+			[ 'someoneelse:theirpassword', 2 ],
+		];
+		foreach ( $userinfoAndPageIds as [ $userinfo, $pageId ] ) {
+			$rows = $this->getExternalLinksRows( "http://$userinfo@example.com/", $pageId );
+			$this->db->insert( 'externallinks', $rows, __METHOD__ );
+		}
+
+		$externalLinks = $this->newExternalLinks();
+		$result = $externalLinks->pageIdsContainingUrl( 'http://me:mypassword@example.com/' );
+
+		$this->assertSame( [ '1' ], $result );
+	}
+
 	public function testPageIdsContainingNothing() {
 		$url = 'http://something.not.found';
 		$externalLinks = $this->newExternalLinks();


### PR DESCRIPTION
The `el_index` field does not contain all the information in the URL – for instance, it discards the username and password (if the URL contains any). This means that, while we can use it to speed up the query, we still need to compare the `el_to` field as well in order to ensure that we only include page IDs for the right URL.

Bug: [T282650](https://phabricator.wikimedia.org/T282650)