### PR TITLE
Inject Wikibase services into EditEndpoint

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,7 @@
 			"path": "/wikibase-reconcile-edit/v0/edit",
 			"method": "POST",
 			"class": "MediaWiki\\Extension\\WikibaseReconcileEdit\\MediaWiki\\Api\\EditEndpoint",
+			"factory": "MediaWiki\\Extension\\WikibaseReconcileEdit\\MediaWiki\\Api\\EditEndpoint::factory",
 			"services": [
 				"WikibaseReconcileEdit.ExternalLinks"
 			]


### PR DESCRIPTION
On REL1_35, they’re not yet available in the MediaWiki service container, but getting them in the `factory()` method and injecting them into the constructor is still better than getting them in the `run()` method. One thing this lets us do is inject a fake property datatype lookup in the test, which is probably more efficient than creating and saving a real property.

We pass the `PropertyDataTypeLookup` into the `MinimalItemInput` constructor, but apart from that the item input constructors still get their services from the default `WikibaseRepo` instance. I assume we’ll turn these into services of their own later.

Bug: [T282244](https://phabricator.wikimedia.org/T282244)