### PR TITLE
Split reconciliation logic to it's own service

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -21,10 +21,9 @@
 			"class": "MediaWiki\\Extension\\WikibaseReconcileEdit\\MediaWiki\\Api\\EditEndpoint",
 			"factory": "MediaWiki\\Extension\\WikibaseReconcileEdit\\MediaWiki\\Api\\EditEndpoint::factory",
 			"services": [
-				"TitleFactory",
-				"WikibaseReconcileEdit.ExternalLinks",
 				"WikibaseReconcileEdit.FullWikibaseItemInput",
-				"WikibaseReconcileEdit.MinimalItemInput"
+				"WikibaseReconcileEdit.MinimalItemInput",
+				"WikibaseReconcileEdit.ReconciliationService"
 			]
 		}
 	],

--- a/includes/MediaWiki/Api/EditEndpoint.php
+++ b/includes/MediaWiki/Api/EditEndpoint.php
@@ -159,7 +159,7 @@ class EditEndpoint extends SimpleHandler {
 		$reconciliationDataValue = $reconciliationMainSnak->getDataValue();
 		$reconciliationUrl = $reconciliationDataValue->getValue();
 
-		$reconciliationItem = $this->reconciliationService->getItemByStatementUrl(
+		$reconciliationItem = $this->reconciliationService->getOrCreateItemByStatementUrl(
 			$reconcileUrlProperty,
 			$reconciliationUrl
 		);

--- a/includes/MediaWiki/ReconciliationItem.php
+++ b/includes/MediaWiki/ReconciliationItem.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki;
+
+use Wikibase\DataModel\Entity\Item;
+
+/**
+ * Class that contains the item and revision found by the reconciliation service
+ * @see ReconciliationService
+ */
+class ReconciliationItem {
+
+	/** @var Item */
+	private $item;
+
+	/** @var int|bool */
+	private $revision;
+
+	public function __construct( Item $item, $revision ) {
+		$this->item = $item;
+		$this->revision = $revision;
+	}
+
+	/**
+	 * @return Item
+	 */
+	public function getItem(): Item {
+		return $this->item;
+	}
+
+	/**
+	 * @return bool|int
+	 */
+	public function getRevision() {
+		return $this->revision;
+	}
+
+}

--- a/includes/MediaWiki/ReconciliationService.php
+++ b/includes/MediaWiki/ReconciliationService.php
@@ -57,11 +57,6 @@ class ReconciliationService {
 	 */
 	private function getItemIdsFromPageIds( array $pageIds ) : array {
 		$titles = $this->titleFactory->newFromIDs( $pageIds );
-
-		if ( empty( $titles ) ) {
-			return [];
-		}
-
 		$entityIds = $this->entityIdLookup->getEntityIds( $titles );
 		$itemIds = [];
 		foreach ( $entityIds as $entityId ) {

--- a/includes/MediaWiki/ReconciliationService.php
+++ b/includes/MediaWiki/ReconciliationService.php
@@ -81,7 +81,7 @@ class ReconciliationService {
 	 * @return ReconciliationItem
 	 * @throws \Exception
 	 */
-	public function getItemByStatementUrl(
+	public function getOrCreateItemByStatementUrl(
 		PropertyID $reconcileUrlProperty,
 		string $reconciliationUrl
 	) : ReconciliationItem {

--- a/includes/MediaWiki/ReconciliationService.php
+++ b/includes/MediaWiki/ReconciliationService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki;
+
+use TitleFactory;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\EntityLookup;
+use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\Lib\Store\EntityIdLookup;
+use Wikibase\Lib\Store\EntityRevisionLookup;
+use Wikibase\Repo\Store\IdGenerator;
+
+/**
+ * Service for reconciling items based on url statements
+ */
+class ReconciliationService {
+
+	/** @var EntityIdLookup */
+	private $entityIdLookup;
+
+	/** @var EntityLookup */
+	private $entityLookup;
+
+	/** @var EntityRevisionLookup */
+	private $entityRevisionLookup;
+
+	/** @var IdGenerator */
+	private $idGenerator;
+
+	/** @var ExternalLinks */
+	private $externalLinks;
+
+	/** @var TitleFactory */
+	private $titleFactory;
+
+	public function __construct(
+		EntityIdLookup $entityIdLookup,
+		EntityLookup $entityLookup,
+		EntityRevisionLookup $entityRevisionLookup,
+		IdGenerator $idGenerator,
+		ExternalLinks $externalLinks,
+		TitleFactory $titleFactory
+	) {
+		$this->entityIdLookup = $entityIdLookup;
+		$this->entityLookup = $entityLookup;
+		$this->entityRevisionLookup = $entityRevisionLookup;
+		$this->idGenerator = $idGenerator;
+		$this->externalLinks = $externalLinks;
+		$this->titleFactory = $titleFactory;
+	}
+
+	/**
+	 * @param int[] $pageIds
+	 * @return ItemId[]
+	 */
+	private function getItemIdsFromPageIds( array $pageIds ) : array {
+		$titles = $this->titleFactory->newFromIDs( $pageIds );
+
+		if ( empty( $titles ) ) {
+			return [];
+		}
+
+		$entityIds = $this->entityIdLookup->getEntityIds( $titles );
+		$itemIds = [];
+		foreach ( $entityIds as $entityId ) {
+			if ( $entityId instanceof ItemId ) {
+				$itemIds[] = $entityId;
+			}
+		}
+		return $itemIds;
+	}
+
+	/**
+	 * Finds existing item or returns a new one if no matching item is found.
+	 * Lookup is matching on items with statement ($reconcileUrlProperty) set to the $reconciliationUrl
+	 *
+	 * @param PropertyId $reconcileUrlProperty
+	 * @param string $reconciliationUrl
+	 * @return ReconciliationItem
+	 * @throws \Exception
+	 */
+	public function getItemByStatementUrl(
+		PropertyID $reconcileUrlProperty,
+		string $reconciliationUrl
+	) : ReconciliationItem {
+		// Find Items that use the URL
+		$itemIdsThatReferenceTheUrl = $this->getItemIdsFromPageIds(
+			$this->externalLinks->pageIdsContainingUrl( $reconciliationUrl )
+		);
+
+		// Find Items that match the URL and Property ID
+		$itemsThatReferenceTheUrlInCorrectStatement = [];
+		foreach ( $itemIdsThatReferenceTheUrl as $itemId ) {
+			/** @var Item $item */
+			$item = $this->entityLookup->getEntity( $itemId );
+
+			foreach ( $item->getStatements()->getByPropertyId( $reconcileUrlProperty )->toArray() as $statement ) {
+				if ( !$statement->getMainSnak() instanceof PropertyValueSnak ) {
+					continue;
+				}
+				/** @var PropertyValueSnak $mainSnak */
+				$mainSnak = $statement->getMainSnak();
+
+				$urlOfStatement = $mainSnak->getDataValue()->getValue();
+				if ( $urlOfStatement === $reconciliationUrl ) {
+					$itemsThatReferenceTheUrlInCorrectStatement[] = $item;
+				}
+			}
+		}
+
+		// If we have more than one item matches, something is wrong and we can't edit
+		if ( count( $itemsThatReferenceTheUrlInCorrectStatement ) > 1 ) {
+			die( 'Matched multiple Items during reconciliation :(' );
+		}
+
+		// Get our base
+		if ( count( $itemsThatReferenceTheUrlInCorrectStatement ) === 1 ) {
+			$base = $itemsThatReferenceTheUrlInCorrectStatement[0];
+			// XXX: This bit is so annoying...
+			$baseRevId = $this->entityRevisionLookup
+				->getLatestRevisionId( $base->getId() )
+				->onConcreteRevision( function ( $revId ) {
+					return $revId;
+				} )
+				->onRedirect( function () {
+					throw new \RuntimeException();
+				} )
+				->onNonexistentEntity( function () {
+					throw new \RuntimeException();
+				} )
+				->map();
+		} else {
+			$base = new Item();
+			$baseRevId = false;
+			// XXX: this is a bit evil, but needed to work around the fact we want to mint statement guids
+			$base->setId( ItemId::newFromNumber( $this->idGenerator->getNewId( 'wikibase-item' ) ) );
+		}
+
+		return new ReconciliationItem( $base, $baseRevId );
+	}
+
+}

--- a/includes/MediaWiki/WikibaseReconcileEditServices.php
+++ b/includes/MediaWiki/WikibaseReconcileEditServices.php
@@ -13,6 +13,11 @@ class WikibaseReconcileEditServices {
 		// should not be instantiated
 	}
 
+	public static function getReconciliationService( ContainerInterface $services = null ): ReconciliationService {
+		return ( $services ?: MediaWikiServices::getInstance() )
+			->get( 'WikibaseReconcileEdit.ReconciliationService' );
+	}
+
 	public static function getExternalLinks( ContainerInterface $services = null ): ExternalLinks {
 		return ( $services ?: MediaWikiServices::getInstance() )
 			->get( 'WikibaseReconcileEdit.ExternalLinks' );

--- a/includes/MediaWiki/WikibaseReconcileEditServices.php
+++ b/includes/MediaWiki/WikibaseReconcileEditServices.php
@@ -13,11 +13,6 @@ class WikibaseReconcileEditServices {
 		// should not be instantiated
 	}
 
-	public static function getReconciliationService( ContainerInterface $services = null ): ReconciliationService {
-		return ( $services ?: MediaWikiServices::getInstance() )
-			->get( 'WikibaseReconcileEdit.ReconciliationService' );
-	}
-
 	public static function getExternalLinks( ContainerInterface $services = null ): ExternalLinks {
 		return ( $services ?: MediaWikiServices::getInstance() )
 			->get( 'WikibaseReconcileEdit.ExternalLinks' );
@@ -31,6 +26,11 @@ class WikibaseReconcileEditServices {
 	public static function getMinimalItemInput( ContainerInterface $services = null ): MinimalItemInput {
 		return ( $services ?: MediaWikiServices::getInstance() )
 			->get( 'WikibaseReconcileEdit.MinimalItemInput' );
+	}
+
+	public static function getReconciliationService( ContainerInterface $services = null ): ReconciliationService {
+		return ( $services ?: MediaWikiServices::getInstance() )
+			->get( 'WikibaseReconcileEdit.ReconciliationService' );
 	}
 
 }

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -3,6 +3,7 @@
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\FullWikibaseItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use MediaWiki\MediaWikiServices;
 use Wikibase\Repo\WikibaseRepo;
 
@@ -30,6 +31,19 @@ return [
 		return new MinimalItemInput(
 			$repo->getPropertyDataTypeLookup(),
 			$repo->getValueParserFactory()
+		);
+	},
+
+	'WikibaseReconcileEdit.ReconciliationService' => function ( MediaWikiServices $services ): ReconciliationService {
+		$repo = WikibaseRepo::getDefaultInstance();
+
+		return new ReconciliationService(
+			$repo->getEntityIdLookup(),
+			$repo->getEntityLookup(),
+			$repo->getEntityRevisionLookup(),
+			$repo->newIdGenerator(),
+			$services->get( 'WikibaseReconcileEdit.ExternalLinks' ),
+			$services->getTitleFactory()
 		);
 	},
 

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -4,6 +4,7 @@ use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\FullWikibaseItemInpu
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\WikibaseReconcileEditServices;
 use MediaWiki\MediaWikiServices;
 use Wikibase\Repo\WikibaseRepo;
 
@@ -42,7 +43,7 @@ return [
 			$repo->getEntityLookup(),
 			$repo->getEntityRevisionLookup(),
 			$repo->newIdGenerator(),
-			$services->get( 'WikibaseReconcileEdit.ExternalLinks' ),
+			WikibaseReconcileEditServices::getExternalLinks( $services ),
 			$services->getTitleFactory()
 		);
 	},

--- a/tests/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/integration/MediaWiki/Api/EditEndpointTest.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\WikibaseReconcileEdit\Test\MediaWiki\Api;
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\WikibaseReconcileEditServices;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\LocalizedHttpException;
@@ -48,21 +49,23 @@ class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 		$repo = WikibaseRepo::getDefaultInstance();
 
 		return new EditEndpoint(
-			MediaWikiServices::getInstance()->getTitleFactory(),
 			$repo->newEditEntityFactory(),
-			$repo->getEntityIdLookup(),
-			$repo->getEntityLookup(),
-			$repo->getEntityRevisionLookup(),
-			$repo->newIdGenerator(),
 			$propertyDataTypeLookup,
-			new ExternalLinks(
-				LoadBalancerSingle::newFromConnection( $this->db )
-			),
 			WikibaseReconcileEditServices::getFullWikibaseItemInput(),
 			new MinimalItemInput(
 				$propertyDataTypeLookup,
 				$repo->getValueParserFactory()
-			)
+			),
+			new ReconciliationService(
+				$repo->getEntityIdLookup(),
+				$repo->getEntityLookup(),
+				$repo->getEntityRevisionLookup(),
+				$repo->newIdGenerator(),
+				new ExternalLinks(
+					LoadBalancerSingle::newFromConnection( $this->db )
+				),
+				MediaWikiServices::getInstance()->getTitleFactory()
+			),
 		);
 	}
 

--- a/tests/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/integration/MediaWiki/Api/EditEndpointTest.php
@@ -4,10 +4,7 @@ namespace MediaWiki\Extension\WikibaseReconcileEdit\Test\MediaWiki\Api;
 
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint;
-use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;
-use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\WikibaseReconcileEditServices;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Rest\LocalizedHttpException;
 use MediaWiki\Rest\RequestData;
 use MediaWiki\Rest\RequestInterface;
@@ -19,7 +16,6 @@ use Wikibase\DataModel\Services\Lookup\InMemoryDataTypeLookup;
 use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookupException;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\Repo\WikibaseRepo;
-use Wikimedia\Rdbms\LoadBalancerSingle;
 
 /**
  * @covers MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint
@@ -56,16 +52,7 @@ class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 				$propertyDataTypeLookup,
 				$repo->getValueParserFactory()
 			),
-			new ReconciliationService(
-				$repo->getEntityIdLookup(),
-				$repo->getEntityLookup(),
-				$repo->getEntityRevisionLookup(),
-				$repo->newIdGenerator(),
-				new ExternalLinks(
-					LoadBalancerSingle::newFromConnection( $this->db )
-				),
-				MediaWikiServices::getInstance()->getTitleFactory()
-			),
+			WikibaseReconcileEditServices::getReconciliationService(),
 		);
 	}
 

--- a/tests/unit/MediaWiki/ReconciliationServiceTest.php
+++ b/tests/unit/MediaWiki/ReconciliationServiceTest.php
@@ -27,11 +27,19 @@ class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
 	public function testNoExternalLinksFound() {
 		$expectedItem = new Item( new ItemId( 'Q10' ) );
 
-		$entityIdLookup = $this->createMock( EntityIdLookup::class );
-
 		$entityLookup = $this->createMock( EntityLookup::class );
 		$entityLookup->expects( $this->never() )
 			->method( 'getEntity' );
+
+		$titleFactory = $this->createMock( TitleFactory::class );
+		$titleFactory->method( 'newFromIDs' )
+			->with( [] )
+			->willReturn( [] );
+
+		$entityIdLookup = $this->createMock( EntityIdLookup::class );
+		$entityIdLookup->method( 'getEntityIds' )
+			->with( [] )
+			->willReturn( [] );
 
 		$entityRevisionLookup = $this->createMock( EntityRevisionLookup::class );
 		$entityRevisionLookup->expects( $this->never() )
@@ -46,8 +54,6 @@ class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
 		$externalLinks->expects( $this->once() )
 			->method( 'pageIdsContainingUrl' )
 			->willReturn( [] );
-
-		$titleFactory = $this->createMock( TitleFactory::class );
 
 		$service = new ReconciliationService(
 			$entityIdLookup,

--- a/tests/unit/MediaWiki/ReconciliationServiceTest.php
+++ b/tests/unit/MediaWiki/ReconciliationServiceTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Unit\MediaWiki;
+
+use DataValues\StringValue;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
+use Title;
+use TitleFactory;
+use Wikibase\DataModel\Entity\Item;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\DataModel\Services\Lookup\EntityLookup;
+use Wikibase\DataModel\Snak\PropertyValueSnak;
+use Wikibase\DataModel\Statement\Statement;
+use Wikibase\DataModel\Statement\StatementList;
+use Wikibase\Lib\Store\EntityIdLookup;
+use Wikibase\Lib\Store\EntityRevisionLookup;
+use Wikibase\Lib\Store\LatestRevisionIdResult;
+use Wikibase\Repo\Store\IdGenerator;
+use Wikibase\Repo\WikibaseRepo;
+
+/**
+ * @covers \MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService
+ */
+class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
+
+	public function testBasicConstruction() {
+		$service = new ReconciliationService(
+			$this->createMock( EntityIdLookup::class ),
+			$this->createMock( EntityLookup::class ),
+			$this->createMock( EntityRevisionLookup::class ),
+			WikibaseRepo::getDefaultInstance()->newIdGenerator(),
+			$this->createMock( ExternalLinks::class ),
+			$this->createMock( TitleFactory::class )
+		);
+
+		$this->assertInstanceOf( ReconciliationService::class, $service );
+	}
+
+	public function testNoExternalLinksFound() {
+		$expectedItem = new Item( new ItemId( 'Q10' ) );
+
+		$entityIdLookup = $this->createMock( EntityIdLookup::class );
+
+		$entityLookup = $this->createMock( EntityLookup::class );
+		$entityLookup->expects( $this->never() )
+			->method( 'getEntity' );
+
+		$entityRevisionLookup = $this->createMock( EntityRevisionLookup::class );
+		$entityRevisionLookup->expects( $this->never() )
+			->method( 'getLatestRevisionId' );
+
+		$idGenerator = $this->createMock( IdGenerator::class );
+		$idGenerator->expects( $this->once() )
+			->method( 'getNewId' )
+			->willReturn( 10 );
+
+		$externalLinks = $this->createMock( ExternalLinks::class );
+		$externalLinks->expects( $this->once() )
+			->method( 'pageIdsContainingUrl' )
+			->willReturn( [] );
+
+		$titleFactory = $this->createMock( TitleFactory::class );
+
+		$service = new ReconciliationService(
+			$entityIdLookup,
+			$entityLookup,
+			$entityRevisionLookup,
+			$idGenerator,
+			$externalLinks,
+			$titleFactory
+		);
+
+		$propertyId = new PropertyId( 'P1' );
+		$reconcileUrl = "http://www.something-nice";
+
+		$reconcileItem = $service->getItemByStatementUrl( $propertyId, $reconcileUrl );
+
+		$this->assertEquals( $expectedItem, $reconcileItem->getItem() );
+		$this->assertFalse( $reconcileItem->getRevision() );
+	}
+
+	public function reconciliationProvider() {
+		$p1 = new PropertyId( 'P1' );
+		$someUrl = 'http://some-url';
+
+		yield 'matches on string url' => [
+			$p1,
+			$someUrl,
+			new ItemId( 'Q1' ),
+			new StatementList(
+				new Statement(
+					new PropertyValueSnak(
+						$p1,
+						new StringValue( $someUrl )
+					)
+				)
+			),
+			// revision
+			1234
+		];
+
+		yield 'in external links but does not match on string url' => [
+			$p1,
+			$someUrl,
+			new ItemId( 'Q1' ),
+			new StatementList(
+				new Statement(
+					new PropertyValueSnak(
+						$p1,
+						new StringValue( 'http://some-other-url' )
+					)
+				)
+			),
+			false
+		];
+
+		yield 'does not have statements' => [
+			$p1,
+			$someUrl,
+			new ItemId( 'Q1' ),
+			new StatementList( [] ),
+			false
+		];
+	}
+
+	/**
+	 * @dataProvider reconciliationProvider
+	 *
+	 * @param PropertyId $reconcilePropertyId
+	 * @param string $reconcileUrl
+	 * @param ItemId $itemId
+	 * @param StatementList $itemStatements
+	 * @param int|false $revision
+	 */
+	public function testGetItemByStatementUrlFoundSomething(
+		PropertyId $reconcilePropertyId,
+		string $reconcileUrl,
+		ItemId $itemId,
+		StatementList $itemStatements,
+		$revision
+	) {
+		$newItemIDNumeric = 10;
+		$newItemID = new ItemId( 'Q' . $newItemIDNumeric );
+
+		$item = new Item( $itemId );
+		$item->setStatements( $itemStatements );
+
+		$pageId = 1;
+
+		$externalLinks = $this->createMock( ExternalLinks::class );
+		$externalLinks->method( 'pageIdsContainingUrl' )
+			->with( $reconcileUrl )
+			->willReturn( [ $pageId ] );
+
+		$titleFactory = $this->createMock( TitleFactory::class );
+		$titleFactory->method( 'newFromIDs' )
+			->with( [ $pageId ] )
+			->willReturn( [ Title::newFromID( $pageId ) ] );
+
+		$entityIdLookup = $this->createMock( EntityIdLookup::class );
+		$entityIdLookup->method( 'getEntityIds' )
+			->with( [ Title::newFromID( $pageId ) ] )
+			->willReturn( [ $itemId ] );
+
+		$entityLookup = $this->createMock( EntityLookup::class );
+		$entityLookup->method( 'getEntity' )
+			->with( $itemId )
+			->willReturn( $item );
+
+		$entityRevisionLookup = $this->createMock( EntityRevisionLookup::class );
+		$idGenerator = $this->createMock( IdGenerator::class );
+
+		// id generator should not be run if revision was found
+		if ( !$revision ) {
+			$idGenerator->expects( $this->once() )
+				->method( 'getNewId' )
+				->willReturn( $newItemIDNumeric );
+		} else {
+
+			$entityRevisionLookup->method( 'getLatestRevisionId' )
+				->willReturn( LatestRevisionIdResult::concreteRevision( $revision ) );
+
+			$idGenerator->expects( $this->never() )
+				->method( 'getNewId' );
+		}
+
+		$service = new ReconciliationService(
+			$entityIdLookup,
+			$entityLookup,
+			$entityRevisionLookup,
+			$idGenerator,
+			$externalLinks,
+			$titleFactory
+		);
+
+		$reconcileItem = $service->getItemByStatementUrl( $reconcilePropertyId, $reconcileUrl );
+
+		$this->assertEquals( $revision ? $itemId : $newItemID, $reconcileItem->getItem()->getId() );
+		$this->assertEquals( $revision, $reconcileItem->getRevision() );
+	}
+}

--- a/tests/unit/MediaWiki/ReconciliationServiceTest.php
+++ b/tests/unit/MediaWiki/ReconciliationServiceTest.php
@@ -18,25 +18,11 @@ use Wikibase\Lib\Store\EntityIdLookup;
 use Wikibase\Lib\Store\EntityRevisionLookup;
 use Wikibase\Lib\Store\LatestRevisionIdResult;
 use Wikibase\Repo\Store\IdGenerator;
-use Wikibase\Repo\WikibaseRepo;
 
 /**
  * @covers \MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService
  */
 class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
-
-	public function testBasicConstruction() {
-		$service = new ReconciliationService(
-			$this->createMock( EntityIdLookup::class ),
-			$this->createMock( EntityLookup::class ),
-			$this->createMock( EntityRevisionLookup::class ),
-			WikibaseRepo::getDefaultInstance()->newIdGenerator(),
-			$this->createMock( ExternalLinks::class ),
-			$this->createMock( TitleFactory::class )
-		);
-
-		$this->assertInstanceOf( ReconciliationService::class, $service );
-	}
 
 	public function testNoExternalLinksFound() {
 		$expectedItem = new Item( new ItemId( 'Q10' ) );
@@ -75,7 +61,7 @@ class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
 		$propertyId = new PropertyId( 'P1' );
 		$reconcileUrl = "http://www.something-nice";
 
-		$reconcileItem = $service->getItemByStatementUrl( $propertyId, $reconcileUrl );
+		$reconcileItem = $service->getOrCreateItemByStatementUrl( $propertyId, $reconcileUrl );
 
 		$this->assertEquals( $expectedItem, $reconcileItem->getItem() );
 		$this->assertFalse( $reconcileItem->getRevision() );
@@ -195,7 +181,7 @@ class ReconciliationServiceTest extends \MediaWikiUnitTestCase {
 			$titleFactory
 		);
 
-		$reconcileItem = $service->getItemByStatementUrl( $reconcilePropertyId, $reconcileUrl );
+		$reconcileItem = $service->getOrCreateItemByStatementUrl( $reconcilePropertyId, $reconcileUrl );
 
 		$this->assertEquals( $revision ? $itemId : $newItemID, $reconcileItem->getItem()->getId() );
 		$this->assertEquals( $revision, $reconcileItem->getRevision() );


### PR DESCRIPTION
- Splits out the reconciliation part of EditEndpoint to it's own service
- Adds some unit tests
- Currently never hitting ->die which is being refactored out.

Bug: T282243