### PR TITLE
Add WikibaseReconcileEditServicesTest

### DIFF
--- a/tests/unit/MediaWiki/WikibaseReconcileEditServicesTest.php
+++ b/tests/unit/MediaWiki/WikibaseReconcileEditServicesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Unit\MediaWiki;
+
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\WikibaseReconcileEditServices;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @covers \MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\WikibaseReconcileEditServices
+ */
+class WikibaseReconcileEditServicesTest extends TestCase {
+
+	public function testServiceAccessorsExistInRightOrder() {
+		$serviceInstantiators = require __DIR__ . '/../../../includes/ServiceWiring.php';
+		$serviceWiringServiceNames = [];
+		foreach ( $serviceInstantiators as $serviceName => $serviceInstantiator ) {
+			$prefix = 'WikibaseReconcileEdit.';
+			$this->assertStringStartsWith( $prefix, $serviceName );
+			$serviceWiringServiceNames[] = substr( $serviceName, strlen( $prefix ) );
+		}
+
+		$reflectionClass = new ReflectionClass( WikibaseReconcileEditServices::class );
+		$accessorServiceNames = [];
+		foreach ( $reflectionClass->getMethods() as $method ) {
+			if ( $method->isConstructor() ) {
+				continue;
+			}
+			$methodName = $method->getName();
+			$prefix = 'get';
+			$this->assertStringStartsWith( $prefix, $methodName );
+			$accessorServiceNames[] = substr( $methodName, strlen( $prefix ) );
+		}
+
+		$this->assertSame( $serviceWiringServiceNames, $accessorServiceNames );
+	}
+
+}


### PR DESCRIPTION
This tests that the lists of services in the wiring file and the accessor class are identical, effectively ensuring that each service has an accessor function, that the class contains no non-accessor functions (other than a private constructor), and that the accessor functions are in the “right” order (the same order as in the wiring file, where we have `/** @phpcs-require-sorted-array */`).

Other tests can be added later, probably based on Wikibase’s `WikibaseRepoTest` or `WikibaseClientTest` (or possibly even extracting a base class for service wiring test files into a library?), but I didn’t want to spend too much time on this for now.

Bug: [T282551](https://phabricator.wikimedia.org/T282551)