### PR TITLE
Stop clearing wb_property_info table in EditEndpointTest

### DIFF
--- a/tests/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/integration/MediaWiki/Api/EditEndpointTest.php
@@ -31,7 +31,6 @@ class EditEndpointTest extends \MediaWikiIntegrationTestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->tablesUsed[] = 'page';
-		$this->tablesUsed[] = 'wb_property_info';
 	}
 
 	private function newHandler() {


### PR DESCRIPTION
Follow-up to fbb0043c7b (#11): since we inject a fake property datatype lookup instead of creating a real property, we no longer need to wipe the property info table between tests.

Bug: [T282244](https://phabricator.wikimedia.org/T282244)