### PR TITLE
Use only EntityRevisionLookup in ReconciliationService

### DIFF
--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -40,7 +40,6 @@ return [
 
 		return new ReconciliationService(
 			$repo->getEntityIdLookup(),
-			$repo->getEntityLookup(),
 			$repo->getEntityRevisionLookup(),
 			$repo->newIdGenerator(),
 			WikibaseReconcileEditServices::getExternalLinks( $services ),


### PR DESCRIPTION
This lets us get rid of the very ugly code to consume the `getLatestRevisionId()` result, and also ensures the item content and revision ID belong together (since they now come from the same source).

Bug: [T282553](https://phabricator.wikimedia.org/T282553)