### PR TITLE
Continue replacement of die with proper error handling

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,5 +15,6 @@
 	"wikibasereconcileedit-editendpoint-qualifiers-references-not-supported": "Qualifiers and References are not currently supported",
 	"wikibasereconcileedit-editendpoint-reconciliation-property-missing-in-statements": "Entity must have at least one statement for the reconciliation Property",
 	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Reconciliation statement must contain a value",
-	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "The reconciliation is ambiguous; matched {{PLURAL:$2|item|$2 items}}: $1"
+	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "The reconciliation is ambiguous; matched {{PLURAL:$2|item|$2 items}}: $1",
+	"wikibasereconcileedit-minimaliteminput-required-keys": "Statements missing '$1' key"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,5 +14,5 @@
 	"wikibasereconcileedit-editendpoint-invalid-entity-input-version": "Unknown entity input version $1; the only supported {{PLURAL:$3|version is|versions are}} $2",
 	"wikibasereconcileedit-editendpoint-qualifiers-references-not-supported": "Qualifiers and References are not currently supported",
 	"wikibasereconcileedit-editendpoint-reconciliation-property-missing-in-statements": "Entity must have at least one statement for the reconciliation Property",
-	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Reconciliation statement must be of type value"
+	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Reconciliation statement must contain a value"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,5 +14,6 @@
 	"wikibasereconcileedit-editendpoint-invalid-entity-input-version": "Unknown entity input version $1; the only supported {{PLURAL:$3|version is|versions are}} $2",
 	"wikibasereconcileedit-editendpoint-qualifiers-references-not-supported": "Qualifiers and References are not currently supported",
 	"wikibasereconcileedit-editendpoint-reconciliation-property-missing-in-statements": "Entity must have at least one statement for the reconciliation Property",
-	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Reconciliation statement must contain a value"
+	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Reconciliation statement must contain a value",
+	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "The reconciliation is ambiguous; matched {{PLURAL:$2|item|$2 items}}: $1"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,6 +14,7 @@
 	"wikibasereconcileedit-editendpoint-invalid-entity-input-version": "Error returned by the API if the “entity” request parameter specifies an unsupported version.\n\nParameters:\n* $1 is the specified (unsupported) version, $2 the supported versions, and $3 the number of supported versions\n",
 	"wikibasereconcileedit-editendpoint-qualifiers-references-not-supported": "Error returned by the API if the “entity” request parameter specifies qualifiers and/or references. They are not yet supported.",
 	"wikibasereconcileedit-editendpoint-reconciliation-property-missing-in-statements": "Error returned by the API if the “entity” request parameter doesn't contain a statement that uses the reconciliation property",
-	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Error returned by the API if the “entity” request parameter of the reconciliation statement's mainsnak is not of type value",
-	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "Error returned by the API if the reconciliation request matches multiple items.\n\nParameters:\n* $1 – the matched items (comma-separated list)\n* $2 – the number of matched items"
+	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Error returned by the API if the “entity” request parameter if the reconciliation statement's mainsnak is not of type value",
+	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "Error returned by the API if the reconciliation request matches multiple items.\n\nParameters:\n* $1 – the matched items (comma-separated list)\n* $2 – the number of matched items",
+	"wikibasereconcileedit-minimaliteminput-required-keys": "Error returned by the API if the minimal item input statements parameter is missing a certain key.\n\nParameters:\n $1 - the missing key"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -14,5 +14,6 @@
 	"wikibasereconcileedit-editendpoint-invalid-entity-input-version": "Error returned by the API if the “entity” request parameter specifies an unsupported version.\n\nParameters:\n* $1 is the specified (unsupported) version, $2 the supported versions, and $3 the number of supported versions\n",
 	"wikibasereconcileedit-editendpoint-qualifiers-references-not-supported": "Error returned by the API if the “entity” request parameter specifies qualifiers and/or references. They are not yet supported.",
 	"wikibasereconcileedit-editendpoint-reconciliation-property-missing-in-statements": "Error returned by the API if the “entity” request parameter doesn't contain a statement that uses the reconciliation property",
-	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Error returned by the API if the “entity” request parameter if the reconciliation statement's mainsnak is not of type value"
+	"wikibasereconcileedit-editendpoint-invalid-reconciliation-statement-type": "Error returned by the API if the “entity” request parameter of the reconciliation statement's mainsnak is not of type value",
+	"wikibasereconcileedit-reconciliationservice-matched-multiple-items": "Error returned by the API if the reconciliation request matches multiple items.\n\nParameters:\n* $1 – the matched items (comma-separated list)\n* $2 – the number of matched items"
 }

--- a/includes/InputToEntity/MinimalItemInput.php
+++ b/includes/InputToEntity/MinimalItemInput.php
@@ -2,6 +2,7 @@
 
 namespace MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity;
 
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationException;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationItem;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use ValueParsers\ParserOptions;
@@ -12,6 +13,7 @@ use Wikibase\DataModel\Services\Lookup\PropertyDataTypeLookup;
 use Wikibase\DataModel\SiteLink;
 use Wikibase\DataModel\Snak\PropertyValueSnak;
 use Wikibase\Repo\ValueParserFactory;
+use Wikimedia\Message\MessageValue;
 
 class MinimalItemInput {
 
@@ -76,11 +78,18 @@ class MinimalItemInput {
 
 		if ( array_key_exists( 'statements', $inputEntity ) ) {
 			foreach ( $inputEntity['statements'] as $statementDetails ) {
-				if (
-					!array_key_exists( 'property', $statementDetails ) ||
-					!array_key_exists( 'value', $statementDetails )
-				) {
-					die( 'statements must have property and value keys' );
+				if ( !array_key_exists( 'property', $statementDetails ) ) {
+					throw new ReconciliationException(
+						MessageValue::new(
+							'wikibasereconcileedit-minimaliteminput-required-keys' )
+							->textParams( 'property' )
+					);
+				} elseif ( !array_key_exists( 'value', $statementDetails ) ) {
+					throw new ReconciliationException(
+						MessageValue::new(
+							'wikibasereconcileedit-minimaliteminput-required-keys' )
+							->textParams( 'value' )
+					);
 				}
 				$propertyId = new PropertyId( $statementDetails['property'] );
 				[ $dataValue, $reconciliationItems ] = $this->getDataValue(

--- a/includes/InputToEntity/MinimalItemInput.php
+++ b/includes/InputToEntity/MinimalItemInput.php
@@ -2,7 +2,6 @@
 
 namespace MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity;
 
-use DataValues\DataValue;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationItem;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use ValueParsers\ParserOptions;
@@ -122,9 +121,6 @@ class MinimalItemInput {
 		// TODO add specific options?
 		$parser = $this->valueParserFactory->newParser( $name, new ParserOptions );
 		$parseResult = $parser->parse( $value );
-		if ( !$parseResult instanceof DataValue ) {
-			die( 'Failed to parse statement value' );
-		}
 		return [ $parseResult, [] ];
 	}
 

--- a/includes/MediaWiki/ReconciliationException.php
+++ b/includes/MediaWiki/ReconciliationException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki;
+
+use Exception;
+use Wikimedia\Message\MessageValue;
+
+/**
+ * Base class for all WikibaseReconcileEdit exceptions
+ *
+ * @license GPL-2.0-or-later
+ */
+class ReconciliationException extends Exception {
+	/**
+	 * @var MessageValue
+	 */
+	private $messageValue;
+
+	public function __construct( MessageValue $messageValue, $errorData = null ) {
+		parent::__construct(
+			'Reconciliation exception with key ' . $messageValue->getKey(), $errorData
+		);
+		$this->messageValue = $messageValue;
+	}
+
+	public function getMessageValue() {
+		return $this->messageValue;
+	}
+}

--- a/tests/phpunit/unit/InputToEntity/MinimalItemInputTest.php
+++ b/tests/phpunit/unit/InputToEntity/MinimalItemInputTest.php
@@ -3,6 +3,7 @@
 namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Unit\InputToEntity;
 
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
+use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationException;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ReconciliationService;
 use MediaWiki\Extension\WikibaseReconcileEdit\Wikibase\FluidItem;
 use ValueParsers\StringParser;
@@ -104,6 +105,58 @@ class MinimalItemInputTest extends \MediaWikiUnitTestCase {
 	private function mockReconciliationService() {
 		$mock = $this->createMock( ReconciliationService::class );
 		return $mock;
+	}
+
+	public function testStatementsHavePropertyKey() {
+		$requestEntityMissingProperty = [
+			'wikibasereconcileedit-version' => '0.0.1/minimal',
+			'statements' => [
+				[
+					'value' => 'im-a-string',
+				],
+			],
+		];
+		$sut = new MinimalItemInput(
+			$this->mockPropertyDataTypeLookup(),
+			$this->mockValueParserFactory(),
+			$this->mockReconciliationService()
+		);
+
+		$prop = new PropertyId( 'P23' );
+
+		try {
+			$new = $sut->getItem( $requestEntityMissingProperty, $prop );
+			$this->fail( 'expected ReconciliationException to be thrown' );
+		} catch ( ReconciliationException $rex ) {
+			$this->assertSame( 'wikibasereconcileedit-minimaliteminput-required-keys',
+				$rex->getMessageValue()->getKey() );
+		}
+	}
+
+	public function testStatementsHaveValueKey() {
+		$requestEntityMissingValue = [
+			'wikibasereconcileedit-version' => '0.0.1/minimal',
+			'statements' => [
+				[
+					'property' => 'P23',
+				],
+			],
+		];
+		$sut = $sut = new MinimalItemInput(
+			$this->mockPropertyDataTypeLookup(),
+			$this->mockValueParserFactory(),
+			$this->mockReconciliationService()
+		);
+
+		$prop = new PropertyId( 'P23' );
+
+		try {
+			$new = $sut->getItem( $requestEntityMissingValue, $prop );
+			$this->fail( 'expected ReconciliationException to be thrown' );
+		} catch ( ReconciliationException $rex ) {
+			$this->assertSame( 'wikibasereconcileedit-minimaliteminput-required-keys',
+				$rex->getMessageValue()->getKey() );
+		}
 	}
 
 }


### PR DESCRIPTION
* Fix invalid-reconciliation-statement-type message
* Multiple item matches
* Remove 'die' for DataValue Exception
* Minimal Input Statement Missing Property or Value Keys