### PR TITLE
[T282860.3] Run api tests on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
               run: |
                   npm install
                   npm run api-testing-lint
+    api-testing:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            -   name: Run API-tests
+                run: |
+                    bash ./build/ci-scripts/run-api-tests.sh
+
+            - name: Archive docker test artifacts
+              uses: actions/upload-artifact@v2
+              if: always()
+              with:
+                  name: TestArtifacts
+                  path: |
+                      build/ci-scripts/log
     ci:
         runs-on: ubuntu-latest
         strategy:
@@ -76,3 +92,4 @@ jobs:
               run: |
                   cd ..
                   php mediawiki/tests/phpunit/phpunit.php mediawiki/extensions/WikibaseReconcileEdit/tests/phpunit/integration
+

--- a/build/ci-scripts/LocalSettings.api-testing.php
+++ b/build/ci-scripts/LocalSettings.api-testing.php
@@ -1,0 +1,3 @@
+<?php
+
+wfLoadExtension( "WikibaseReconcileEdit" );

--- a/build/ci-scripts/api-testing.config.json
+++ b/build/ci-scripts/api-testing.config.json
@@ -5,8 +5,5 @@
 		"name": "admin",
 		"password": "secret-password"
 	},
-	"secret_key": "abcdef",
-	"extra_parameters": {
-		"xdebug_session": "PHPSTORM"
-	}
+	"secret_key": "secret-key"
 }

--- a/build/ci-scripts/api-testing.config.json
+++ b/build/ci-scripts/api-testing.config.json
@@ -1,0 +1,12 @@
+{
+	"base_uri": "http://localhost:8484/w/",
+	"main_page": "Main_Page",
+	"root_user": {
+		"name": "admin",
+		"password": "secret-password"
+	},
+	"secret_key": "abcdef",
+	"extra_parameters": {
+		"xdebug_session": "PHPSTORM"
+	}
+}

--- a/build/ci-scripts/docker-compose.yml
+++ b/build/ci-scripts/docker-compose.yml
@@ -18,7 +18,7 @@ services:
             - DB_SERVER=mysql.svc:3306
             - MW_ADMIN_NAME=admin
             - MW_ADMIN_PASS=secret-password
-            - MW_WG_SECRET_KEY=secretkey
+            - MW_WG_SECRET_KEY=secret-key
             - DB_USER=root
             - DB_PASS=root
             - DB_NAME=test_db_wiki

--- a/build/ci-scripts/docker-compose.yml
+++ b/build/ci-scripts/docker-compose.yml
@@ -1,0 +1,43 @@
+# Wikibase for api-testing releases
+version: '3'
+
+services:
+    wikibase:
+        image: wikibase/wikibase:1.35.2-wmde.1
+        restart: unless-stopped
+        volumes:
+            - ../../../WikibaseReconcileEdit:/var/www/html/extensions/WikibaseReconcileEdit
+            - ../../../WikibaseReconcileEdit/build/ci-scripts/LocalSettings.api-testing.php:/var/www/html/LocalSettings.d/LocalSettings.api-testing.php
+        ports:
+            - "8484:80"
+        networks:
+            default:
+                aliases:
+                    - wikibase.svc
+        environment:
+            - DB_SERVER=mysql.svc:3306
+            - MW_ADMIN_NAME=admin
+            - MW_ADMIN_PASS=secret-password
+            - MW_WG_SECRET_KEY=secretkey
+            - DB_USER=root
+            - DB_PASS=root
+            - DB_NAME=test_db_wiki
+            - MW_ADMIN_EMAIL=admin@wikimedia.de
+    mysql:
+        image: mariadb:10.3
+        restart: unless-stopped
+        volumes:
+            - mediawiki-mysql-data:/var/lib/mysql
+        environment:
+            MYSQL_DATABASE: test_db_wiki
+            MYSQL_USER: root
+            MYSQL_PASSWORD: root
+            MYSQL_ROOT_PASSWORD: root
+        networks:
+            default:
+                aliases:
+                    - mysql.svc
+
+volumes:
+    LocalSettings:
+    mediawiki-mysql-data:

--- a/build/ci-scripts/run-api-tests.sh
+++ b/build/ci-scripts/run-api-tests.sh
@@ -1,0 +1,17 @@
+cd build/ci-scripts/
+cp api-testing.config.json ../../.api-testing.config.json
+mkdir log
+docker-compose up -d
+docker-compose logs -f --no-color > "log/wikibase.api-testing.log" &
+
+cd -
+
+if docker run --rm curlimages/curl:7.71.0 --fail --retry 60 --retry-all-errors --retry-delay 1 --max-time 10 --retry-max-time 60 --show-error --output /dev/null --silent http://172.17.0.1:8484/wiki/Main_Page; then
+	echo "Successfully started!"
+else
+	echo "Could not load instance."
+	exit 1
+fi
+
+npm install
+npm run api-testing


### PR DESCRIPTION
This adds another job for running the api-testing specs against a
Wikibase instance with WikibaseReconcileEdit enabled.

This currently only runs against 1.35.2-wmde.1 but could with some
modifications run from a matrix of releases.