### PR TITLE
Move integration tests under Integration

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,6 +9,10 @@
 	"AutoloadNamespaces": {
 		"MediaWiki\\Extension\\WikibaseReconcileEdit\\": "includes/"
 	},
+	"TestAutoloadNamespaces": {
+		"MediaWiki\\Extension\\WikibaseReconcileEdit\\Tests\\Integration\\": "tests/phpunit/integration/",
+		"MediaWiki\\Extension\\WikibaseReconcileEdit\\Tests\\Unit\\": "tests/phpunit/unit/"
+	},
 	"MessagesDirs": {
 		"WikibaseReconcileEdit": [
 			"i18n"

--- a/tests/phpunit/integration/MediaWiki/Api/EditEndpointTest.php
+++ b/tests/phpunit/integration/MediaWiki/Api/EditEndpointTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MediaWiki\Extension\WikibaseReconcileEdit\Test\MediaWiki\Api;
+namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Integration\MediaWiki\Api;
 
 use MediaWiki\Extension\WikibaseReconcileEdit\InputToEntity\MinimalItemInput;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\Api\EditEndpoint;

--- a/tests/phpunit/integration/MediaWiki/ExternalLinksTest.php
+++ b/tests/phpunit/integration/MediaWiki/ExternalLinksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Unit\EditStrategy;
+namespace MediaWiki\Extension\WikibaseReconcileEdit\Tests\Integration\Mediawiki;
 
 use LinkFilter;
 use MediaWiki\Extension\WikibaseReconcileEdit\MediaWiki\ExternalLinks;


### PR DESCRIPTION
I think this is correct? 

`EditEndpointTest` should be under `MediaWiki\Extension\WikibaseReconcileEdit\Tests\Integration\MediaWiki\Api`

`ExternalLinksTest` should be under `MediaWiki\Extension\WikibaseReconcileEdit\Tests\Integration\Mediawiki`